### PR TITLE
fixing the Content-Type to formdata for events api

### DIFF
--- a/wavefront_client/apis/events_api.py
+++ b/wavefront_client/apis/events_api.py
@@ -114,7 +114,7 @@ class EventsApi(object):
 
         # HTTP header `Content-Type`
         header_params['Content-Type'] = self.api_client.\
-            select_header_content_type([])
+            select_header_content_type(['application/x-www-form-urlencoded'])
 
         # Authentication setting
         auth_settings = ['api_key']


### PR DESCRIPTION
the content type for most api is `application/x-www-form-urlencoded` but the generated api code sets it to `application/json` 
I have done a hotfix for events api as I want to share this with a customer. But this should content type should be fixed for rest of the generated code for api's 