### PR TITLE
fixing the Content-Type to formdata for create event call

### DIFF
--- a/wavefront_client/apis/events_api.py
+++ b/wavefront_client/apis/events_api.py
@@ -211,8 +211,8 @@ class EventsApi(object):
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
-            select_header_content_type([])
+        header_params['Content-Type'] = self.api_client. \
+            select_header_content_type(['application/x-www-form-urlencoded'])
 
         # Authentication setting
         auth_settings = ['api_key']


### PR DESCRIPTION
did not set the `application/x-www-form-urlencoded`  in `create_new_event` function in PR #3 . fixing it here
