### PR TITLE
MONIT-9897/Fix for prefix not required for custom metrics.

### DIFF
--- a/wavefront_lambda/README.md
+++ b/wavefront_lambda/README.md
@@ -55,4 +55,4 @@ The Lambda wrapper adds the following point tags to all metrics sent to wavefron
 
 ## Custom Lambda Metrics
 
-The wavefront lambda wrapper reports custom business metrics via a pyformance plugin. Please refer to the [code sample](https://github.com/wavefrontHQ/python-client/blob/master/wavefront_pyformance/example.py) for details.
+The wavefront lambda wrapper reports custom business metrics via a metrics registry provided by the [pyformance plugin](https://github.com/wavefrontHQ/python-client/tree/master/wavefront_pyformance). Please refer to the [code sample](https://github.com/wavefrontHQ/python-client/blob/master/wavefront_lambda/example.py) for details.

--- a/wavefront_lambda/README.md
+++ b/wavefront_lambda/README.md
@@ -14,7 +14,7 @@ pip install wavefront_lambda
 ## Environmental variables
 WAVEFRONT_URL = https://\<INSTANCE>.wavefront.com  
 WAVEFRONT_API_TOKEN = Wavefront API token with Direct Data Ingestion permission.  
-IS_REPORT_STANDARD_METRICS = Set to False to not report standard lambda metrics directly to wavefront.  
+IS_REPORT_STANDARD_METRICS = Set to False or false to not report standard lambda metrics directly to wavefront.  
 
 ## Usage
 
@@ -52,3 +52,7 @@ The Lambda wrapper adds the following point tags to all metrics sent to wavefron
 | FunctionName          | The name of Lambda function.                                                  |
 | Resource              | Execution time of the Lambda.                                                 |
 | EventSourceMappings   | AWS Function Name (In case of an event source mapping Lambda invocation only,)|
+
+## Custom Lambda Metrics
+
+The wavefront lambda wrapper reports custom business metrics via a pyformance plugin. Please refer to the [code sample](https://github.com/wavefrontHQ/python-client/blob/master/wavefront_pyformance/example.py) for details.

--- a/wavefront_lambda/README.md
+++ b/wavefront_lambda/README.md
@@ -55,4 +55,4 @@ The Lambda wrapper adds the following point tags to all metrics sent to wavefron
 
 ## Custom Lambda Metrics
 
-The wavefront lambda wrapper reports custom business metrics via a metrics registry provided by the [pyformance plugin](https://github.com/wavefrontHQ/python-client/tree/master/wavefront_pyformance). Please refer to the [code sample](https://github.com/wavefrontHQ/python-client/blob/master/wavefront_lambda/example.py) for details.
+The wavefront lambda wrapper reports custom business metrics via a metrics registry provided by the [pyformance plugin](https://github.com/wavefrontHQ/python-client/tree/master/wavefront_pyformance). Please refer to the [code sample](https://github.com/wavefrontHQ/python-client/blob/master/wavefront_lambda/example.py) which shows how you can send custom business metrics to wavefront from your lambda function.

--- a/wavefront_lambda/README.md
+++ b/wavefront_lambda/README.md
@@ -55,4 +55,5 @@ The Lambda wrapper adds the following point tags to all metrics sent to wavefron
 
 ## Custom Lambda Metrics
 
-The wavefront lambda wrapper reports custom business metrics via a metrics registry provided by the [pyformance plugin](https://github.com/wavefrontHQ/python-client/tree/master/wavefront_pyformance). Please refer to the [code sample](https://github.com/wavefrontHQ/python-client/blob/master/wavefront_lambda/example.py) which shows how you can send custom business metrics to wavefront from your lambda function.
+The wavefront lambda wrapper reports custom business metrics via a metrics registry provided by the [pyformance plugin](https://github.com/wavefrontHQ/python-client/tree/master/wavefront_pyformance).  
+Please refer to the [code sample](https://github.com/wavefrontHQ/python-client/blob/master/wavefront_lambda/example.py) which shows how you can send custom business metrics to wavefront from your lambda function.

--- a/wavefront_lambda/wavefront_lambda/__init__.py
+++ b/wavefront_lambda/wavefront_lambda/__init__.py
@@ -20,16 +20,17 @@ def wrapper(func):
 
     """
     def call_lambda_with_standard_metrics(wf_reporter, *args, **kwargs):
+        METRIC_PREFIX = "aws.lambda.wf."
         # Set cold start counter
         global is_cold_start
         if is_cold_start:
-            aws_cold_starts_counter = delta.delta_counter(reg, "aws.lambda.wf.coldstarts")
+            aws_cold_starts_counter = delta.delta_counter(reg, METRIC_PREFIX + "coldstarts")
             aws_cold_starts_counter.inc()
-            aws_cold_starts_normal_counter = reg.counter("aws.lambda.wf.coldstarts_raw")
+            aws_cold_starts_normal_counter = reg.counter(METRIC_PREFIX + "coldstarts_raw")
             aws_cold_starts_normal_counter.inc()
             is_cold_start = False
         # Set invocations counter
-        aws_lambda_invocations_counter = delta.delta_counter(reg, "aws.lambda.wf.invocations")
+        aws_lambda_invocations_counter = delta.delta_counter(reg, METRIC_PREFIX + "invocations")
         aws_lambda_invocations_counter.inc()
         time_start = datetime.now()
         try:
@@ -37,13 +38,13 @@ def wrapper(func):
             return result
         except:
             # Set error counter
-            aws_lambda_errors_counter = delta.delta_counter(reg, "aws.lambda.wf.errors")
+            aws_lambda_errors_counter = delta.delta_counter(reg, METRIC_PREFIX + "errors")
             aws_lambda_errors_counter.inc()
             raise
         finally:
             time_taken = datetime.now() - time_start
             # Set duration Gauge
-            aws_lambda_duration_gauge = reg.gauge("aws.lambda.wf.duration")
+            aws_lambda_duration_gauge = reg.gauge(METRIC_PREFIX + "duration")
             aws_lambda_duration_gauge.set_value(time_taken.total_seconds() * 1000)
             wf_reporter.report_now(registry=reg)
 

--- a/wavefront_lambda/wavefront_lambda/__init__.py
+++ b/wavefront_lambda/wavefront_lambda/__init__.py
@@ -23,13 +23,13 @@ def wrapper(func):
         # Set cold start counter
         global is_cold_start
         if is_cold_start:
-            aws_cold_starts_counter = delta.delta_counter(reg, "coldstarts")
+            aws_cold_starts_counter = delta.delta_counter(reg, "aws.lambda.wf.coldstarts")
             aws_cold_starts_counter.inc()
-            aws_cold_starts_normal_counter = reg.counter("coldstarts_raw")
+            aws_cold_starts_normal_counter = reg.counter("aws.lambda.wf.coldstarts_raw")
             aws_cold_starts_normal_counter.inc()
             is_cold_start = False
         # Set invocations counter
-        aws_lambda_invocations_counter = delta.delta_counter(reg, "invocations")
+        aws_lambda_invocations_counter = delta.delta_counter(reg, "aws.lambda.wf.invocations")
         aws_lambda_invocations_counter.inc()
         time_start = datetime.now()
         try:
@@ -37,13 +37,13 @@ def wrapper(func):
             return result
         except:
             # Set error counter
-            aws_lambda_errors_counter = delta.delta_counter(reg, "errors")
+            aws_lambda_errors_counter = delta.delta_counter(reg, "aws.lambda.wf.errors")
             aws_lambda_errors_counter.inc()
             raise
         finally:
             time_taken = datetime.now() - time_start
             # Set duration Gauge
-            aws_lambda_duration_gauge = reg.gauge("duration")
+            aws_lambda_duration_gauge = reg.gauge("aws.lambda.wf.duration")
             aws_lambda_duration_gauge.set_value(time_taken.total_seconds() * 1000)
             wf_reporter.report_now(registry=reg)
 
@@ -98,7 +98,7 @@ def wrapper(func):
                                                      registry=reg,
                                                      source=point_tags['FunctionName'],
                                                      tags=point_tags,
-                                                     prefix="aws.lambda.wf.")
+                                                     prefix="")
 
         if is_report_standard_metrics:
             call_lambda_with_standard_metrics(wf_direct_reporter,


### PR DESCRIPTION
There should be no prefix for custom metrics being reported. Modify to keep the prefix only for standard lambda metrics.

Please review: @vikramraman  @sushantdewan123 