### PR TITLE
Allow Event's 'end_time' to be None.

### DIFF
--- a/wavefront_api_client/models/event.py
+++ b/wavefront_api_client/models/event.py
@@ -523,10 +523,8 @@ class Event(object):
         :param end_time: The end_time of this Event.  # noqa: E501
         :type: int
         """
-        if end_time is None:
-            raise ValueError("Invalid value for `end_time`, must not be `None`")  # noqa: E501
-
-        self._end_time = end_time
+        if end_time is not None:
+            self._end_time = end_time
 
     @property
     def running_state(self):


### PR DESCRIPTION
This should fix the error thrown for ongoing events.

```
>>> import wavefront_api_client
>>> _config = wavefront_api_client.Configuration()
>>> _config.host = 'https://<your_host>.wavefront.com'
>>> event_api_client = wavefront_api_client.EventApi(wavefront_api_client.ApiClient(configuration=_config, header_name='Authorization', header_value='Bearer <YOUR_API_TOKEN>'))
>>> event_api_client.get_event('1525902632435:ongoing-test-event')  # an ongoing event id
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/wavefront_api_client/api/event_api.py", line 550, in get_event
    (data) = self.get_event_with_http_info(id, **kwargs)  # noqa: E501
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/wavefront_api_client/api/event_api.py", line 624, in get_event_with_http_info
    collection_formats=collection_formats)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/wavefront_api_client/api_client.py", line 322, in call_api
    _preload_content, _request_timeout)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/wavefront_api_client/api_client.py", line 161, in __call_api
    return_data = self.deserialize(response_data, response_type)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/wavefront_api_client/api_client.py", line 233, in deserialize
    return self.__deserialize(data, response_type)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/wavefront_api_client/api_client.py", line 272, in __deserialize
    return self.__deserialize_model(data, klass)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/wavefront_api_client/api_client.py", line 613, in __deserialize_model
    kwargs[attr] = self.__deserialize(value, attr_type)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/wavefront_api_client/api_client.py", line 272, in __deserialize
    return self.__deserialize_model(data, klass)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/wavefront_api_client/api_client.py", line 615, in __deserialize_model
    instance = klass(**kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/wavefront_api_client/models/event.py", line 136, in __init__
    self.end_time = end_time
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/wavefront_api_client/models/event.py", line 527, in end_time
    raise ValueError("Invalid value for `end_time`, must not be `None`")  # noqa: E501
ValueError: Invalid value for `end_time`, must not be `None`
```