### PR TITLE
Update Minimum Versions for Required Packages.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ VERSION = "2.3.2"
 REQUIRES = ["certifi>=2017.4.17",
             "python-dateutil>=2.1",
             "six>=1.10",
-            "urllib3>=1.15"]
+            "urllib3>=1.21.1"]
 
 setup(
     name=NAME,

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,10 @@ VERSION = "2.3.2"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["urllib3 >= 1.15", "six >= 1.10", "certifi", "python-dateutil"]
+REQUIRES = ["certifi>=2017.4.17",
+            "python-dateutil>=2.1",
+            "six>=1.10",
+            "urllib3>=1.15"]
 
 setup(
     name=NAME,


### PR DESCRIPTION
Set "certifi>=2017.4.17" to keep it aligned with popular 'requests' package.
Set "python-dateutil>=2.1" to make it not conflict with 'botocore' package.